### PR TITLE
Upgrade Jedis to fix incompatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
 
 ext.versions = [
     "sdk": "5.0.0", // the *lowest* version we're compatible with
-    "jedis": "2.9.0",
+    "jedis": "3.3.0",
     "slf4j": "1.7.21"
 ]
 

--- a/src/main/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreImpl.java
+++ b/src/main/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreImpl.java
@@ -20,7 +20,7 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.Transaction;
-import redis.clients.util.JedisURIHelper;
+import redis.clients.jedis.util.JedisURIHelper;
 
 final class RedisDataStoreImpl implements PersistentDataStore {
   private static final Logger logger = LoggerFactory.getLogger("com.launchdarkly.sdk.server.LDClient.DataStore.Redis");
@@ -135,7 +135,7 @@ final class RedisDataStoreImpl implements PersistentDataStore {
         Transaction tx = jedis.multi();
         tx.hset(baseKey, key, jsonOrPlaceholder(kind, newItem));
         List<Object> result = tx.exec();
-        if (result.isEmpty()) {
+        if (result == null || result.isEmpty()) {
           // if exec failed, it means the watch was triggered and we should retry
           logger.debug("Concurrent modification detected, retrying");
           continue;


### PR DESCRIPTION
in Jedis 3, the `util` package moved to `jedis.util`.  This causes issues when trying to use this library in an application using Jedis 3.  My fix here is to upgrade Jedis to the latest.

The only test failure this caused was `handlesUpsertRaceConditionAgainstExternalClientWithLowerVersion`; this is fixed by adding that null check.