### PR TITLE
Add Jedis 3 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,8 @@ jobs:
       - run: cp gradle.properties.example gradle.properties
       - run:
           name: Edit build.gradle to change Jedis version
-          command: sed -i.bak "s#\"jedis\":.*\"[0-9.]*\"#\"jedis\": \"<<parameters.jedis-version>\"#" build.gradle
+          command: |
+            sed -i.bak 's#"jedis":.*"[0-9.]*"#"jedis":"<<parameters.jedis-version>"#' build.gradle
       - run: ./gradlew test
       - run: ./gradlew javadoc
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ workflows:
 jobs:
   build-test-linux:
     docker:
-      - image: cimg/openjdk:8
+      - image: cimg/openjdk:8.0
       - image: redis
     steps:
       - checkout
@@ -38,7 +38,7 @@ jobs:
       jedis-version:
         type: string
     docker:
-      - image: cimg/openjdk:8
+      - image: cimg/openjdk:8.0
       - image: redis
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,16 +7,45 @@ workflows:
   test:
     jobs:
       - build-test-linux
+      - build-test-linux-with-other-jedis-version:
+          name: test with Jedis 3.x
+          jedis-version: 3.0.0
       - build-test-windows
 
 jobs:
   build-test-linux:
     docker:
-      - image: circleci/java
+      - image: cimg/openjdk:8
       - image: redis
     steps:
       - checkout
       - run: cp gradle.properties.example gradle.properties
+      - run: ./gradlew test
+      - run: ./gradlew javadoc
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/;
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: ~/junit
+
+  build-test-linux-with-other-jedis-version:
+    parameters:
+      jedis-version:
+        type: string
+    docker:
+      - image: cimg/openjdk:8
+      - image: redis
+    steps:
+      - checkout
+      - run: cp gradle.properties.example gradle.properties
+      - run:
+          name: Edit build.gradle to change Jedis version
+          command: sed -i.bak "s#\"jedis\":.*\"[0-9.]*\"#\"jedis\": \"<<parameters.jedis-version>\"#" build.gradle
       - run: ./gradlew test
       - run: ./gradlew javadoc
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - run:
           name: Edit build.gradle to change Jedis version
           command: |
-            sed -i.bak 's#"jedis":.*"[0-9.]*"#"jedis":"<<parameters.jedis-version>"#' build.gradle
+            sed -i.bak 's#"jedis":.*"[0-9.]*"#"jedis":"<<parameters.jedis-version>>"#' build.gradle
       - run: ./gradlew test
       - run: ./gradlew javadoc
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # Eclipse project files
 .classpath
 .project
- 
+.settings
+
 # Intellij project files
 *.iml
 *.ipr

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This assumes that you have already installed the LaunchDarkly Java SDK.
           <version>2.9.0</version>
         </dependency>
 
+    This library is compatible with Jedis 2.x versions greater than or equal to 2.9.0, and also with Jedis 3.x.
+
 3. Import the LaunchDarkly package and the package for this library:
 
         import com.launchdarkly.sdk.server.*;

--- a/src/main/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreImpl.java
+++ b/src/main/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreImpl.java
@@ -20,7 +20,6 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.Transaction;
-import redis.clients.util.JedisURIHelper;
 
 final class RedisDataStoreImpl implements PersistentDataStore {
   private static final Logger logger = LoggerFactory.getLogger("com.launchdarkly.sdk.server.LDClient.DataStore.Redis");
@@ -35,8 +34,8 @@ final class RedisDataStoreImpl implements PersistentDataStore {
     // to decompose the URI.
     String host = builder.uri.getHost();
     int port = builder.uri.getPort();
-    String password = builder.password == null ? JedisURIHelper.getPassword(builder.uri) : builder.password;
-    int database = builder.database == null ? JedisURIHelper.getDBIndex(builder.uri): builder.database.intValue();
+    String password = builder.password == null ? RedisURIComponents.getPassword(builder.uri) : builder.password;
+    int database = builder.database == null ? RedisURIComponents.getDBIndex(builder.uri): builder.database.intValue();
     boolean tls = builder.tls || builder.uri.getScheme().equals("rediss");
     
     String extra = tls ? " with TLS" : "";

--- a/src/main/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreImpl.java
+++ b/src/main/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreImpl.java
@@ -134,7 +134,7 @@ final class RedisDataStoreImpl implements PersistentDataStore {
         Transaction tx = jedis.multi();
         tx.hset(baseKey, key, jsonOrPlaceholder(kind, newItem));
         List<Object> result = tx.exec();
-        if (result.isEmpty()) {
+        if (result == null || result.isEmpty()) {
           // if exec failed, it means the watch was triggered and we should retry
           logger.debug("Concurrent modification detected, retrying");
           continue;

--- a/src/main/java/com/launchdarkly/sdk/server/integrations/RedisURIComponents.java
+++ b/src/main/java/com/launchdarkly/sdk/server/integrations/RedisURIComponents.java
@@ -1,0 +1,26 @@
+package com.launchdarkly.sdk.server.integrations;
+
+import java.net.URI;
+
+/**
+ * This class contains methods equivalent to those in JedisURIHelper. Avoiding the use of
+ * JedisURIHelper allows us to be compatible with both Jedis 2.x and Jedis 3.x, because
+ * that class doesn't exist in the same location in both versions.
+ */
+abstract class RedisURIComponents {
+  static String getPassword(URI uri) {
+    if (uri.getUserInfo() == null) {
+      return null;
+    }
+    String[] parts = uri.getUserInfo().split(":", 2);
+    return parts.length < 2 ? null : parts[1];
+  }
+  
+  static int getDBIndex(URI uri) {
+    String[] parts = uri.getPath().split("/", 2);
+    if (parts.length < 2 || parts[1].isEmpty()) {
+      return 0;
+    }
+    return Integer.parseInt(parts[1]);
+  }
+}

--- a/src/test/java/com/launchdarkly/sdk/server/integrations/RedisURIComponentsTest.java
+++ b/src/test/java/com/launchdarkly/sdk/server/integrations/RedisURIComponentsTest.java
@@ -1,0 +1,45 @@
+package com.launchdarkly.sdk.server.integrations;
+
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class RedisURIComponentsTest {
+  @Test
+  public void getPasswordForURIWithoutUserInfo() {
+    assertNull(RedisURIComponents.getPassword(URI.create("redis://hostname:6379")));
+  }
+
+  @Test
+  public void getPasswordForURIWithUsernameAndNoPassword() {
+    assertNull(RedisURIComponents.getPassword(URI.create("redis://username@hostname:6379")));
+  }
+
+  @Test
+  public void getPasswordForURIWithUsernameAndPassword() {
+    assertEquals("secret", RedisURIComponents.getPassword(URI.create("redis://username:secret@hostname:6379")));
+  }
+
+  @Test
+  public void getPasswordForURIWithPasswordAndNoUsername() {
+    assertEquals("secret", RedisURIComponents.getPassword(URI.create("redis://:secret@hostname:6379")));
+  }
+  
+  @Test
+  public void getDBIndexForURIWithoutPath() {
+    assertEquals(0, RedisURIComponents.getDBIndex(URI.create("redis://hostname:6379")));
+  }
+  
+  @Test
+  public void getDBIndexForURIWithRootPath() {
+    assertEquals(0, RedisURIComponents.getDBIndex(URI.create("redis://hostname:6379/")));
+  }
+
+  @Test
+  public void getDBIndexForURIWithNumberInPath() {
+    assertEquals(2, RedisURIComponents.getDBIndex(URI.create("redis://hostname:6379/2")));
+  }
+}


### PR DESCRIPTION
The minimum version of Jedis we've been building against is 2.9.0, but since we use a fairly limited subset of the Jedis API and it did not change greatly in version 3, we would've been compatible with Jedis 3.x if not for two things:

1. We were using convenience methods from `JedisURIHelper`, which was moved in 3.x.
2. We were assuming that `Transaction.exec()` always returns a non-null value, which is not true in 3.x.

This PR is similar to https://github.com/launchdarkly/java-server-sdk-redis/pull/3 but allows our code to work with both 2.x and 3.x, by avoiding the use of `JedisURIHelper`. In a future release we may want to make 3.0 the minimum version, but this is the least disruptive change for developers who may still be using the older version.