### PR TITLE
Implementation of Big Segments store support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This library provides a Redis-backed persistence mechanism (feature store) for the [LaunchDarkly Java SDK](https://github.com/launchdarkly/java-server-sdk), replacing the default in-memory feature store. The Redis API implementation it uses is [Jedis](https://github.com/xetorthio/jedis).
 
-This version of the library requires at least version 5.0.0 of the LaunchDarkly Java SDK. The minimum Java version is 8.
+Version 2.0.0 and above of this library requires at least version 5.7.0 of the LaunchDarkly Java SDK. For earlier versions of the sdk, use the latest 1.x release of this library. The minimum Java version is 8.
 
 For more information, see also: [Using a persistent feature store](https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This library provides a Redis-backed persistence mechanism (feature store) for the [LaunchDarkly Java SDK](https://github.com/launchdarkly/java-server-sdk), replacing the default in-memory feature store. The Redis API implementation it uses is [Jedis](https://github.com/xetorthio/jedis).
 
-Version 2.0.0 and above of this library requires at least version 5.7.0 of the LaunchDarkly Java SDK. For earlier versions of the sdk, use the latest 1.x release of this library. The minimum Java version is 8.
+This version of the library requires at least version 5.0.0 of the LaunchDarkly Java SDK. The minimum Java version is 8.
 
 For more information, see also: [Using a persistent feature store](https://docs.launchdarkly.com/v2.0/docs/using-a-persistent-feature-store).
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ ext {
 }
 
 ext.versions = [
-    "sdk": "5.0.0", // the *lowest* version we're compatible with
+    "sdk": "5.7.0-SNAPSHOT", // the *lowest* version we're compatible with
     "jedis": "2.9.0",
     "slf4j": "1.7.21"
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ ext {
 }
 
 ext.versions = [
-    "sdk": "5.7.0-SNAPSHOT", // the *lowest* version we're compatible with
+    "sdk": "5.7.0", // the *lowest* version we're compatible with
     "jedis": "2.9.0",
     "slf4j": "1.7.21"
 ]

--- a/src/main/java/com/launchdarkly/sdk/server/integrations/Redis.java
+++ b/src/main/java/com/launchdarkly/sdk/server/integrations/Redis.java
@@ -1,5 +1,9 @@
 package com.launchdarkly.sdk.server.integrations;
 
+import com.launchdarkly.sdk.server.Components;
+import com.launchdarkly.sdk.server.interfaces.PersistentDataStoreFactory;
+import com.launchdarkly.sdk.server.interfaces.BigSegmentStoreFactory;
+
 /**
  * Integration between the LaunchDarkly SDK and Redis.
  * 
@@ -9,17 +13,37 @@ public abstract class Redis {
   /**
    * Returns a builder object for creating a Redis-backed data store.
    * <p>
-   * This object can be modified with {@link RedisDataStoreBuilder} methods for any desired
-   * custom Redis options. Then, pass it to {@link com.launchdarkly.sdk.server.Components#persistentDataStore(com.launchdarkly.sdk.server.interfaces.PersistentDataStoreFactory)}
-   * and set any desired caching options. Finally, pass the result to
-   * {@link com.launchdarkly.sdk.server.LDConfig.Builder#dataStore(com.launchdarkly.sdk.server.interfaces.DataStoreFactory)}.
-   * For example:
-   * 
+   * This can be used either for the main data store that holds feature flag data, or for the Big
+   * Segment store, or both. If you are using both, they do not have to have the same parameters.
+   * For instance, in this example the main data store uses a Redis host called "host1" and the Big
+   * Segment store uses a Redis host called "host2":
    * <pre><code>
    *     LDConfig config = new LDConfig.Builder()
    *         .dataStore(
    *             Components.persistentDataStore(
-   *                 Redis.dataStore().url("redis://my-redis-host")
+   *                 Redis.dataStore().uri(URI.create("redis://host1:6379")
+   *             )
+   *         )
+   *         .bigSegments(
+   *             Components.bigSegments(
+   *                 Redis.dataStore().uri(URI.create("redis://host2:6379")
+   *             )
+   *         )
+   *         .build();
+   * </code></pre>
+   * <p>
+   * Note that the builder is passed to one of two methods,
+   * {@link Components#persistentDataStore(PersistentDataStoreFactory)} or
+   * {@link Components#bigSegments(BigSegmentStoreFactory)}, depending on the context in which it is
+   * being used. This is because each of those contexts has its own additional configuration options
+   * that are unrelated to the Redis options. For instance, the
+   * {@link Components#persistentDataStore(PersistentDataStoreFactory)} builder has options for
+   * caching:
+   * <pre><code>
+   *     LDConfig config = new LDConfig.Builder()
+   *         .dataStore(
+   *             Components.persistentDataStore(
+   *                 Redis.dataStore().uri(URI.create("redis://my-redis-host"))
    *             ).cacheSeconds(15)
    *         )
    *         .build();

--- a/src/main/java/com/launchdarkly/sdk/server/integrations/RedisBigSegmentStoreImpl.java
+++ b/src/main/java/com/launchdarkly/sdk/server/integrations/RedisBigSegmentStoreImpl.java
@@ -1,0 +1,43 @@
+package com.launchdarkly.sdk.server.integrations;
+
+import com.launchdarkly.sdk.server.interfaces.BigSegmentStore;
+import com.launchdarkly.sdk.server.interfaces.BigSegmentStoreTypes;
+
+import java.util.Set;
+
+import redis.clients.jedis.Jedis;
+
+final class RedisBigSegmentStoreImpl extends RedisStoreImplBase implements BigSegmentStore {
+  private static final String LOGGER_NAME = "com.launchdarkly.sdk.server.LDClient.BigSegments.Redis";
+
+  private final String syncTimeKey;
+  private final String includedKeyPrefix;
+  private final String excludedKeyPrefix;
+
+  RedisBigSegmentStoreImpl(RedisDataStoreBuilder builder) {
+    super(builder, LOGGER_NAME);
+    syncTimeKey = prefix + ":big_segments_synchronized_on";
+    includedKeyPrefix = prefix + ":big_segment_include:";
+    excludedKeyPrefix = prefix + ":big_segment_exclude:";
+  }
+
+  @Override
+  public BigSegmentStoreTypes.Membership getMembership(String userHash) {
+    try (Jedis jedis = pool.getResource()) {
+      Set<String> includedRefs = jedis.smembers(includedKeyPrefix + userHash);
+      Set<String> excludedRefs = jedis.smembers(excludedKeyPrefix + userHash);
+      return BigSegmentStoreTypes.createMembershipFromSegmentRefs(includedRefs, excludedRefs);
+    }
+  }
+
+  @Override
+  public BigSegmentStoreTypes.StoreMetadata getMetadata() {
+    try (Jedis jedis = pool.getResource()) {
+      String value = jedis.get(syncTimeKey);
+      if (value == null || value.isEmpty()) {
+        return null;
+      }
+      return new BigSegmentStoreTypes.StoreMetadata(Long.parseLong(value));
+    }
+  }
+}

--- a/src/main/java/com/launchdarkly/sdk/server/integrations/RedisStoreImplBase.java
+++ b/src/main/java/com/launchdarkly/sdk/server/integrations/RedisStoreImplBase.java
@@ -1,0 +1,59 @@
+package com.launchdarkly.sdk.server.integrations;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+abstract class RedisStoreImplBase implements Closeable {
+  protected final Logger logger;
+  protected final JedisPool pool;
+  protected final String prefix;
+
+  protected RedisStoreImplBase(RedisDataStoreBuilder builder, String loggerName) {
+    logger = LoggerFactory.getLogger(loggerName);
+    // There is no builder for JedisPool, just a large number of constructor overloads. Unfortunately,
+    // the overloads that accept a URI do not accept the other parameters we need to set, so we need
+    // to decompose the URI.
+    String host = builder.uri.getHost();
+    int port = builder.uri.getPort();
+    String password = builder.password == null ? RedisURIComponents.getPassword(builder.uri) : builder.password;
+    int database = builder.database == null ? RedisURIComponents.getDBIndex(builder.uri) : builder.database;
+    boolean tls = builder.tls || builder.uri.getScheme().equals("rediss");
+
+    String extra = tls ? " with TLS" : "";
+    if (password != null) {
+      extra = extra + (extra.isEmpty() ? " with" : " and") + " password";
+    }
+    logger.info(String.format("Using Redis data store at %s:%d/%d%s", host, port, database, extra));
+
+    JedisPoolConfig poolConfig = (builder.poolConfig != null) ? builder.poolConfig : new JedisPoolConfig();
+
+    this.prefix = (builder.prefix == null || builder.prefix.isEmpty()) ?
+        RedisDataStoreBuilder.DEFAULT_PREFIX :
+        builder.prefix;
+    this.pool = new JedisPool(poolConfig,
+        host,
+        port,
+        (int) builder.connectTimeout.toMillis(),
+        (int) builder.socketTimeout.toMillis(),
+        password,
+        database,
+        null, // clientName
+        tls,
+        null, // sslSocketFactory
+        null, // sslParameters
+        null  // hostnameVerifier
+    );
+  }
+
+  @Override
+  public void close() throws IOException {
+    logger.info("Closing Redis store");
+    pool.destroy();
+  }
+}

--- a/src/test/java/com/launchdarkly/sdk/server/integrations/RedisBigSegmentStoreImplTest.java
+++ b/src/test/java/com/launchdarkly/sdk/server/integrations/RedisBigSegmentStoreImplTest.java
@@ -1,0 +1,59 @@
+package com.launchdarkly.sdk.server.integrations;
+
+import static org.junit.Assume.assumeTrue;
+
+import com.launchdarkly.sdk.server.interfaces.BigSegmentStoreFactory;
+import com.launchdarkly.sdk.server.interfaces.BigSegmentStoreTypes;
+
+import org.junit.BeforeClass;
+
+import redis.clients.jedis.Jedis;
+
+@SuppressWarnings("javadoc")
+public class RedisBigSegmentStoreImplTest extends BigSegmentStoreTestBase {
+  @BeforeClass
+  public static void maybeSkipDatabaseTests() {
+    String skipParam = System.getenv("LD_SKIP_DATABASE_TESTS");
+    assumeTrue(skipParam == null || skipParam.equals(""));
+  }
+
+  @Override
+  protected BigSegmentStoreFactory makeStore(String prefix) {
+    return Redis.dataStore().prefix(prefix);
+  }
+
+  @Override
+  protected void clearData(String prefix) {
+    prefix = prefix == null || prefix.isEmpty() ? RedisDataStoreBuilder.DEFAULT_PREFIX : prefix;
+    try (Jedis client = new Jedis("localhost")) {
+      for (String key : client.keys(prefix + ":*")) {
+        client.del(key);
+      }
+    }
+  }
+
+  @Override
+  protected void setMetadata(String prefix, BigSegmentStoreTypes.StoreMetadata storeMetadata) {
+    try (Jedis client = new Jedis("localhost")) {
+      client.set(prefix + ":big_segments_synchronized_on",
+          storeMetadata != null ? Long.toString(storeMetadata.getLastUpToDate()) : "");
+    }
+  }
+
+  @Override
+  protected void setSegments(String prefix,
+                             String userHashKey,
+                             Iterable<String> includedSegmentRefs,
+                             Iterable<String> excludedSegmentRefs) {
+    try (Jedis client = new Jedis("localhost")) {
+      String includeKey = prefix + ":big_segment_include:" + userHashKey;
+      String excludeKey = prefix + ":big_segment_exclude:" + userHashKey;
+      for (String includedSegmentRef : includedSegmentRefs) {
+        client.sadd(includeKey, includedSegmentRef);
+      }
+      for (String excludedSegmentRef : excludedSegmentRefs) {
+        client.sadd(excludeKey, excludedSegmentRef);
+      }
+    }
+  }
+}

--- a/src/test/java/com/launchdarkly/sdk/server/integrations/RedisBigSegmentStoreImplTest.java
+++ b/src/test/java/com/launchdarkly/sdk/server/integrations/RedisBigSegmentStoreImplTest.java
@@ -1,21 +1,12 @@
 package com.launchdarkly.sdk.server.integrations;
 
-import static org.junit.Assume.assumeTrue;
-
 import com.launchdarkly.sdk.server.interfaces.BigSegmentStoreFactory;
 import com.launchdarkly.sdk.server.interfaces.BigSegmentStoreTypes;
-
-import org.junit.BeforeClass;
 
 import redis.clients.jedis.Jedis;
 
 @SuppressWarnings("javadoc")
 public class RedisBigSegmentStoreImplTest extends BigSegmentStoreTestBase {
-  @BeforeClass
-  public static void maybeSkipDatabaseTests() {
-    String skipParam = System.getenv("LD_SKIP_DATABASE_TESTS");
-    assumeTrue(skipParam == null || skipParam.equals(""));
-  }
 
   @Override
   protected BigSegmentStoreFactory makeStore(String prefix) {

--- a/src/test/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreImplTest.java
+++ b/src/test/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreImplTest.java
@@ -1,14 +1,8 @@
 package com.launchdarkly.sdk.server.integrations;
 
-import com.launchdarkly.sdk.server.integrations.Redis;
-import com.launchdarkly.sdk.server.integrations.RedisDataStoreImpl;
 import com.launchdarkly.sdk.server.integrations.RedisDataStoreImpl.UpdateListener;
 
-import org.junit.BeforeClass;
-
 import java.net.URI;
-
-import static org.junit.Assume.assumeTrue;
 
 import redis.clients.jedis.Jedis;
 
@@ -16,12 +10,6 @@ import redis.clients.jedis.Jedis;
 public class RedisDataStoreImplTest extends PersistentDataStoreTestBase<RedisDataStoreImpl> {
 
   private static final URI REDIS_URI = URI.create("redis://localhost:6379");
-  
-  @BeforeClass
-  public static void maybeSkipDatabaseTests() {
-    String skipParam = System.getenv("LD_SKIP_DATABASE_TESTS");
-    assumeTrue(skipParam == null || skipParam.equals(""));
-  }
   
   @Override
   protected RedisDataStoreImpl makeStore() {


### PR DESCRIPTION
Roughly equivalent to https://github.com/launchdarkly/dotnet-server-sdk-redis/pull/18. CI is currently not passing because a version of `java-server-sdk` that supports Big Segments has not yet been published.