### PR TITLE
use new logging API introduced in Java SDK 5.10.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,4 +40,8 @@ To build the library and run all unit tests:
 ./gradlew test
 ```
 
-The tests expect you to have Redis running locally on the default port, 6379. One way to do this is with Docker: `docker run -d -p 6379:6379 redis`
+The tests expect you to have Redis running locally on the default port, 6379. One way to do this is with Docker:
+
+```shell
+docker run -p 6379:6379 redis
+```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This library provides a Redis-backed persistence mechanism (feature store) for the [LaunchDarkly Java SDK](https://github.com/launchdarkly/java-server-sdk), replacing the default in-memory feature store. The Redis API implementation it uses is [Jedis](https://github.com/xetorthio/jedis).
 
-This version of the library requires at least version 5.0.0 of the LaunchDarkly Java SDK. The minimum Java version is 8.
+This version of the library requires at least version 5.10.0 of the LaunchDarkly Java SDK; for earlier 5.x versions of the Java SDK, use the 1.x version of this library. The minimum Java version is 8.
 
 For more information, see also: [Using Redis as a persistent feature store](https://docs.launchdarkly.com/sdk/features/storing-data/redis#java).
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,9 +42,8 @@ ext {
 }
 
 ext.versions = [
-    "sdk": "5.7.0", // the *lowest* version we're compatible with
-    "jedis": "2.9.0",
-    "slf4j": "1.7.21"
+    "sdk": "5.10.0", // the *lowest* version we're compatible with
+    "jedis": "2.9.0"
 ]
 
 ext.libraries = [:]
@@ -52,7 +51,6 @@ ext.libraries = [:]
 dependencies {
     api "com.launchdarkly:launchdarkly-java-server-sdk:${versions.sdk}"
     api "redis.clients:jedis:${versions.jedis}"
-    api "org.slf4j:slf4j-api:${versions.slf4j}"
     testImplementation "org.hamcrest:hamcrest-all:1.3"
     testImplementation "junit:junit:4.12"
     testImplementation "com.launchdarkly:launchdarkly-java-server-sdk:${versions.sdk}:test" // our unit tests use helper classes from the SDK

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,6 @@ dependencies {
     testImplementation "org.hamcrest:hamcrest-all:1.3"
     testImplementation "junit:junit:4.12"
     testImplementation "com.launchdarkly:launchdarkly-java-server-sdk:${versions.sdk}:test" // our unit tests use helper classes from the SDK
-    testImplementation "ch.qos.logback:logback-classic:1.1.7"
     testImplementation "com.google.guava:guava:28.2-jre" // required by SDK tests, not used in this library itself
     testImplementation "com.google.code.gson:gson:2.7" // same as above
 }

--- a/src/main/java/com/launchdarkly/sdk/server/integrations/RedisBigSegmentStoreImpl.java
+++ b/src/main/java/com/launchdarkly/sdk/server/integrations/RedisBigSegmentStoreImpl.java
@@ -1,5 +1,6 @@
 package com.launchdarkly.sdk.server.integrations;
 
+import com.launchdarkly.logging.LDLogger;
 import com.launchdarkly.sdk.server.interfaces.BigSegmentStore;
 import com.launchdarkly.sdk.server.interfaces.BigSegmentStoreTypes;
 
@@ -14,8 +15,8 @@ final class RedisBigSegmentStoreImpl extends RedisStoreImplBase implements BigSe
   private final String includedKeyPrefix;
   private final String excludedKeyPrefix;
 
-  RedisBigSegmentStoreImpl(RedisDataStoreBuilder builder) {
-    super(builder, LOGGER_NAME);
+  RedisBigSegmentStoreImpl(RedisDataStoreBuilder builder, LDLogger baseLogger) {
+    super(builder, baseLogger.subLogger("BigSegments").subLogger("Redis"));
     syncTimeKey = prefix + ":big_segments_synchronized_on";
     includedKeyPrefix = prefix + ":big_segment_include:";
     excludedKeyPrefix = prefix + ":big_segment_exclude:";

--- a/src/main/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreBuilder.java
+++ b/src/main/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreBuilder.java
@@ -185,12 +185,12 @@ public final class RedisDataStoreBuilder
 
   @Override
   public PersistentDataStore createPersistentDataStore(ClientContext context) {
-    return new RedisDataStoreImpl(this);
+    return new RedisDataStoreImpl(this, context.getBasic().getBaseLogger());
   }
 
   @Override
   public BigSegmentStore createBigSegmentStore(ClientContext context) {
-    return new RedisBigSegmentStoreImpl(this);
+    return new RedisBigSegmentStoreImpl(this, context.getBasic().getBaseLogger());
   }
 
   @Override

--- a/src/main/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreImpl.java
+++ b/src/main/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreImpl.java
@@ -1,5 +1,6 @@
 package com.launchdarkly.sdk.server.integrations;
 
+import com.launchdarkly.logging.LDLogger;
 import com.launchdarkly.sdk.server.interfaces.DataStoreTypes.DataKind;
 import com.launchdarkly.sdk.server.interfaces.DataStoreTypes.FullDataSet;
 import com.launchdarkly.sdk.server.interfaces.DataStoreTypes.ItemDescriptor;
@@ -16,12 +17,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Transaction;
 
 final class RedisDataStoreImpl extends RedisStoreImplBase implements PersistentDataStore {
-  private static final String LOGGER_NAME = "com.launchdarkly.sdk.server.LDClient.DataStore.Redis";
-
   private UpdateListener updateListener;
   
-  RedisDataStoreImpl(RedisDataStoreBuilder builder) {
-    super(builder, LOGGER_NAME);
+  RedisDataStoreImpl(RedisDataStoreBuilder builder, LDLogger baseLogger) {
+    super(builder, baseLogger.subLogger("DataStore").subLogger("Redis"));
   }
   
   @Override

--- a/src/main/java/com/launchdarkly/sdk/server/integrations/RedisStoreImplBase.java
+++ b/src/main/java/com/launchdarkly/sdk/server/integrations/RedisStoreImplBase.java
@@ -1,7 +1,6 @@
 package com.launchdarkly.sdk.server.integrations;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.launchdarkly.logging.LDLogger;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -10,12 +9,13 @@ import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 
 abstract class RedisStoreImplBase implements Closeable {
-  protected final Logger logger;
+  protected final LDLogger logger;
   protected final JedisPool pool;
   protected final String prefix;
 
-  protected RedisStoreImplBase(RedisDataStoreBuilder builder, String loggerName) {
-    logger = LoggerFactory.getLogger(loggerName);
+  protected RedisStoreImplBase(RedisDataStoreBuilder builder, LDLogger logger) {
+    this.logger = logger;
+
     // There is no builder for JedisPool, just a large number of constructor overloads. Unfortunately,
     // the overloads that accept a URI do not accept the other parameters we need to set, so we need
     // to decompose the URI.
@@ -29,7 +29,7 @@ abstract class RedisStoreImplBase implements Closeable {
     if (password != null) {
       extra = extra + (extra.isEmpty() ? " with" : " and") + " password";
     }
-    logger.info(String.format("Using Redis data store at %s:%d/%d%s", host, port, database, extra));
+    logger.info("Using Redis data store at {}:{}/{}{}", host, port, database, extra);
 
     JedisPoolConfig poolConfig = (builder.poolConfig != null) ? builder.poolConfig : new JedisPoolConfig();
 

--- a/src/test/java/com/launchdarkly/sdk/server/integrations/RedisBigSegmentStoreImplTest.java
+++ b/src/test/java/com/launchdarkly/sdk/server/integrations/RedisBigSegmentStoreImplTest.java
@@ -2,6 +2,7 @@ package com.launchdarkly.sdk.server.integrations;
 
 import com.launchdarkly.sdk.server.interfaces.BigSegmentStoreFactory;
 import com.launchdarkly.sdk.server.interfaces.BigSegmentStoreTypes;
+import com.launchdarkly.sdk.server.interfaces.ClientContext;
 
 import redis.clients.jedis.Jedis;
 

--- a/src/test/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreBuilderTest.java
+++ b/src/test/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreBuilderTest.java
@@ -42,7 +42,7 @@ public class RedisDataStoreBuilderTest {
   @Test
   public void testDatabaseConfigured() {
     RedisDataStoreBuilder conf = Redis.dataStore().database(3);
-    assertEquals(new Integer(3), conf.database);
+    assertEquals(Integer.valueOf(3), conf.database);
   }
   
   @Test

--- a/src/test/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreImplTest.java
+++ b/src/test/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreImplTest.java
@@ -1,6 +1,7 @@
 package com.launchdarkly.sdk.server.integrations;
 
 import com.launchdarkly.sdk.server.integrations.RedisDataStoreImpl.UpdateListener;
+import com.launchdarkly.sdk.server.interfaces.PersistentDataStoreFactory;
 
 import java.net.URI;
 
@@ -12,13 +13,8 @@ public class RedisDataStoreImplTest extends PersistentDataStoreTestBase<RedisDat
   private static final URI REDIS_URI = URI.create("redis://localhost:6379");
   
   @Override
-  protected RedisDataStoreImpl makeStore() {
-    return (RedisDataStoreImpl)Redis.dataStore().uri(REDIS_URI).createPersistentDataStore(null);
-  }
-  
-  @Override
-  protected RedisDataStoreImpl makeStoreWithPrefix(String prefix) {
-    return (RedisDataStoreImpl)Redis.dataStore().uri(REDIS_URI).prefix(prefix).createPersistentDataStore(null);
+  protected PersistentDataStoreFactory buildStore(String prefix) {
+    return Redis.dataStore().uri(REDIS_URI).prefix(prefix);
   }
   
   @Override


### PR DESCRIPTION
This removes the direct use of SLF4J and directs all logging to the LDLogger that the SDK provides to us.

This makes the library incompatible with SDK versions below 5.10.0, so we'll release the change in a new major version.